### PR TITLE
Update CIRCUS Shellscript paths

### DIFF
--- a/docs/admin/access-token.md
+++ b/docs/admin/access-token.md
@@ -29,7 +29,7 @@ The access token must be stored securely. Someone who knows this access token wi
 Attach to Bash in the CIRCUS container (see [Installation](./installation.mdx)), and run the following commands.
 
 ```shell-session title="Inside the container"
-# /root/servicies.sh &
+# /circus/services.sh &
 # cd /var/circus/circus-api
 # node circus add-permanent-token <LOGIN-NAME-OR-EMAIL>
 ```

--- a/docs/admin/registration-cs-plugin.mdx
+++ b/docs/admin/registration-cs-plugin.mdx
@@ -21,7 +21,7 @@ You need to run this command on the host machine (where `circuscad/circus` itsel
 Start CIRCUS, attach to the container's Bash, and run the following command.
 
 ```
-# /root/cad_plugin_registration.sh [REPOSITORY]:[TAG]
+# /circus/cad_plugin_registration.sh [REPOSITORY]:[TAG]
 ```
 
 You will see a confirmation message like the following. Type "Y" and Enter.
@@ -47,7 +47,7 @@ You can inspect the `[REPOSITORY]` and `[TAG]` needed to import the container us
 1.  Run the following command (in the container) to register the information of the CIRCUS CS plug-in.
 
     ```shell-session title="Inside the container"
-    # /root/servicies.sh &
+    # /circus/services.sh &
     # cd /var/circus/packages/circus-api
     # node circus register-cad-plugin [FULL-IMAGE-ID]
     ```


### PR DESCRIPTION
- Updated /root/\*.sh to /circus/\*.sh (reflecting this update: https://github.com/utrad-ical/circus/commit/b5313f7644b065be20f5528562cbd81339850285)
- Corrected a typo: `servicies.sh` to `services.sh`