### PR TITLE
Remove incorrect `--force` from `docker kill`

### DIFF
--- a/docs/admin/installation.mdx
+++ b/docs/admin/installation.mdx
@@ -123,7 +123,7 @@ $ sudo docker run --rm -v /var/circus/data:/var/circus/data \
   -d -e DAEMON_MODE=1 circuscad/circus:latest
 ```
 
-To stop this container, inspect its ID using `docker ps`, and run `docker kill --force <container-id>`.
+To stop this container, inspect its ID using `docker ps`, and run `docker kill <container-id>`.
 
 ## Check if the Server is Running
 


### PR DESCRIPTION
`docker kill` does not support a `--force` option.